### PR TITLE
feat: push to wikis of other repos

### DIFF
--- a/scripts/deploy-wiki.sh
+++ b/scripts/deploy-wiki.sh
@@ -43,9 +43,9 @@ git add -A
 # now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
 git commit --allow-empty -m "Deploy to GitHub pages [ci skip]"
 # and push, but send any output to /dev/null to hide anything sensitive
-git push --force --quiet codiusd master
-git push --force --quiet codius master
-git push --force --quiet codiuswiki master
+git push --quiet codiusd master
+git push --quiet codius master
+git push --quiet codiuswiki master
 # go back to where we started and remove the gh-pages git repo we made and used
 # for deployment
 cd ..

--- a/scripts/deploy-wiki.sh
+++ b/scripts/deploy-wiki.sh
@@ -34,14 +34,18 @@ ls
 cp -a "../project/." .
 git remote remove origin
 echo "remote removed"
-git remote add origin "git@github.com:codius/codiusd.wiki.git"
+git remote add codiusd "git@github.com:codius/codiusd.wiki.git"
+git remote add codius "git@github.com:codius/codius.wiki.git"
+git remote add codiuswiki "git@github.com:codius/codius-wiki.wiki.git"
 echo "added new remote"
 # stage any changes and new files
 git add -A
 # now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
 git commit --allow-empty -m "Deploy to GitHub pages [ci skip]"
 # and push, but send any output to /dev/null to hide anything sensitive
-git push --force --quiet origin master
+git push --force --quiet codiusd master
+git push --force --quiet codius master
+git push --force --quiet codiuswiki master
 # go back to where we started and remove the gh-pages git repo we made and used
 # for deployment
 cd ..


### PR DESCRIPTION
The script used by CircleCI now creates additional origins to push to. These are the wiki repos for the [codius](https://github.com/codius/codius), [codiusd](https://github.com/codius/codiusd), and [codius-wiki](https://github.com/codius/codius-wiki). The effect is that these three repos will each have a mirror of the wiki, which should make it less confusing to find.